### PR TITLE
push back latest public tag to private repo

### DIFF
--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -7,7 +7,9 @@ export class CdkStack extends cdk.Stack {
   constructor (scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    new DevPipeline(this);
-    new PublicRelease(this);
+    const devPipeline = new DevPipeline(this);
+    new PublicRelease(this, {
+      privateEcrRepo: devPipeline.privateEcrRepo
+    });
   }
 }

--- a/cdk/lib/dev/dev-pipeline.ts
+++ b/cdk/lib/dev/dev-pipeline.ts
@@ -11,6 +11,7 @@ import { DevBuild } from './dev-build';
 import { DevRelease } from './dev-release';
 
 class DevPipeline extends Construct {
+  privateEcrRepo: Repository;
   constructor (scope: Construct) {
     super(scope, 'DevPipeline');
 
@@ -23,6 +24,7 @@ class DevPipeline extends Construct {
       tagStatus: TagStatus.UNTAGGED,
       maxImageCount: 25 
     });
+    this.privateEcrRepo = ecrRepo;
 
     const release = new DevRelease(this, constructId('devRelease'), {
       ecrRepo


### PR DESCRIPTION
## Pull Request Type
 - [x] Feature
 - [ ] Bug Fix

## Summary of Feature
CDK doesn't support importing public ecr images nor using public ecr images for a docker lambda.
This pushes back a latest-public tag to the private repository that we can reference in SaaS stacks.
We may also want to add version-public tags as well.