### PR TITLE
sso fix

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,18 @@ const path = require('path');
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  webpack: (config, { isServer }) => {
+    if (!isServer) {
+      config.resolve.fallback = {
+        ...config.resolve.fallback,
+        fs: false,
+        child_process: false
+      };
+    }
+
+    return config;
+  }
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
- frontend faced build failures after sso changes to ops-aws-core-widgets because v3 sdk functions fromSSO and fromINI functions rely on node packages
- FIX: tell webpack not to throw an error when trying to resolve these node packages