### PR TITLE
ignore cache deps, allow versioned dependencies

### DIFF
--- a/generate-plugins-index.js
+++ b/generate-plugins-index.js
@@ -6,8 +6,9 @@ const processArgs = [...process.argv];
 const dependencies = processArgs.slice(2);
 
 const importStatements = dependencies?.map((dependency) => {
-  const moduleNamespace = camelCase(dependency);
-  return `export * as ${moduleNamespace} from '${dependency}';`;
+  const packageName = `@${dependency.split('@')?.at(1)}`;
+  const moduleNamespace = camelCase(packageName);
+  return `export * as ${moduleNamespace} from '${packageName}';`;
 });
 
 if (importStatements.length === 0) {

--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,9 @@ const nextConfig = {
       config.resolve.fallback = {
         ...config.resolve.fallback,
         fs: false,
-        child_process: false
+        child_process: false,
+        net: false,
+        tls: false
       };
     }
 


### PR DESCRIPTION
1. Ignore `cached` server side only dependencies
2. Allow versioned dependencies to be specified in config (i.e. `@scope/package@version`)