### PR TITLE
added local dependency mapping

### DIFF
--- a/get-runtime-dependencies.sh
+++ b/get-runtime-dependencies.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-defaultDeps="@tinystacks/ops-core-widgets @tinystacks/ops-aws-core-widgets";
+defaultDeps="@tinystacks/ops-core-widgets
+@tinystacks/ops-aws-core-widgets
+@tinystacks/ops-aws-utilization-widgets";
+
 if [ ! -f ".local-dependencies" ];
   then
     touch .local-dependencies;
@@ -15,4 +18,22 @@ if [[ -z "$dependencies" ]];
     dependencies=$(<.local-dependencies);
 fi
 
-echo "$dependencies"
+echo "$2"
+
+getNames=false
+while getopts "n" flag; do
+  case "$flag" in
+    n) getNames=true;;
+  esac
+done;
+
+oneLinerDependencies="";
+while read -r line; do
+  IFS=':' read -ra dependency <<< "$line";
+  name=""
+  if $getNames || [ -z ${dependency[1]} ]; then name=${dependency[0]}; else name=${dependency[1]}; fi;
+  oneLinerDependencies+=" ${name}";
+done <<< "$dependencies";
+oneLinerDependencies=${oneLinerDependencies/ /};
+
+echo "$oneLinerDependencies";

--- a/get-runtime-dependencies.sh
+++ b/get-runtime-dependencies.sh
@@ -18,8 +18,6 @@ if [[ -z "$dependencies" ]];
     dependencies=$(<.local-dependencies);
 fi
 
-echo "$2"
-
 getNames=false
 while getopts "n" flag; do
   case "$flag" in

--- a/local.sh
+++ b/local.sh
@@ -2,10 +2,8 @@
 
 ## Install runtime dependencies
 dependencies=$(bash ./get-runtime-dependencies.sh);
-echo $dependencies;
 npm i --no-save --silent $dependencies --@tinystacks:registry=https://registry.npmjs.org;
 dependencyNames=$(bash ./get-runtime-dependencies.sh -n);
-echo $dependencyNames;
 node ./generate-plugins-index.js $dependencyNames;
 
 ## Setup environment variables

--- a/local.sh
+++ b/local.sh
@@ -2,8 +2,11 @@
 
 ## Install runtime dependencies
 dependencies=$(bash ./get-runtime-dependencies.sh);
+echo $dependencies;
 npm i --no-save --silent $dependencies --@tinystacks:registry=https://registry.npmjs.org;
-node ./generate-plugins-index.js $dependencies;
+dependencyNames=$(bash ./get-runtime-dependencies.sh -n);
+echo $dependencyNames;
+node ./generate-plugins-index.js $dependencyNames;
 
 ## Setup environment variables
 rm -rf ./.env.local;


### PR DESCRIPTION
Can specify local dependency paths in .local-dependencies
Example .local-dependencies:
```
@tinystacks/ops-aws-utilization-widgets:~/workspace/ops-aws-utilization-widgets.tgz
@tinystacks/ops-aws-core-widgets
```