### PR TITLE
Minor Display Enhancements

### DIFF
--- a/src/components/dashboard/dashboard-list.tsx
+++ b/src/components/dashboard/dashboard-list.tsx
@@ -7,6 +7,7 @@ import {
   Flex,
   Heading,
   Spacer,
+  Spinner,
   useDisclosure,
   Wrap
 } from '@chakra-ui/react';
@@ -35,18 +36,22 @@ export function DashboardList () {
   const dispatch = useAppDispatch();
   const [consolesError, setConsolesError] = useState<string | undefined>(undefined);
   const [retryCount, setRetryCount] = useState<number>(0);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
   async function fetchData() {
     try {
+      setIsLoading(true);
       setConsolesError(undefined);
       const consoles = await apis.getConsoles();
       if (Array.isArray(consoles)) {
         // FIXME: we need to eventually only deal with a single console
         dispatch(updateConsole(consoles[0]));
         setRetryCount(0);
+        setIsLoading(false);
       }
     } catch (e: any) {
       setConsolesError(e.message);
       setRetryCount(retryCount + 1);
+      setIsLoading(false);
     }
   }
 
@@ -111,6 +116,11 @@ export function DashboardList () {
     );
   }
 
+  let loader = (<></>);
+  if (isLoading) {
+    loader = <Spinner />
+  }
+
 
   return (
     <>
@@ -121,6 +131,7 @@ export function DashboardList () {
       {errorBanner}
       <FullpageLayout>
         <Wrap data-testid='console-page-contents' spacing="6" maxWidth="7xl">
+          {loader}
           {cards}
         </Wrap>
       </FullpageLayout>

--- a/src/components/dashboard/dashboard-wrapper.tsx
+++ b/src/components/dashboard/dashboard-wrapper.tsx
@@ -2,7 +2,7 @@ import { selectConsoleName, selectDashboards, updateConsole, updateDashboard } f
 import React, { ReactNode, useEffect, useState } from 'react';
 import { useAppDispatch, useAppSelector } from 'ops-frontend/store/hooks';
 import apis from 'ops-frontend/utils/apis';
-import { Button, Flex, Heading, Stack, useDisclosure } from '@chakra-ui/react';
+import { Box, Button, Flex, Heading, Stack, Text, useDisclosure } from '@chakra-ui/react';
 import { HeaderLayout } from 'ops-frontend/components/layout/header-layout';
 import isEmpty from 'lodash.isempty';
 import { FullpageLayout } from 'ops-frontend/components/layout/fullpage-layout';
@@ -12,8 +12,14 @@ import DashboardSettings from 'ops-frontend/components/dashboard/dashboard-setti
 import { Dashboard } from '@tinystacks/ops-model';
 import { useNavigate } from 'react-router-dom';
 
-export function DashboardWrapper(props: { dashboardContents: ReactNode, dashboardId: string }) {
-  const { dashboardContents, dashboardId } = props;
+export type DashboardWrapperProps = {
+  dashboardId: string;
+  description?: string;
+  dashboardContents: ReactNode;
+}
+
+export function DashboardWrapper(props: DashboardWrapperProps) {
+  const { dashboardContents, dashboardId, description } = props;
   const navigate = useNavigate();
   const dashboards = useAppSelector(selectDashboards);
   const consoleName = useAppSelector(selectConsoleName);
@@ -61,20 +67,21 @@ export function DashboardWrapper(props: { dashboardContents: ReactNode, dashboar
 
   function renderHeader() {
     return (
-      <>
-      <Flex justify='space-between'>
-        <Heading>{dashboardId}</Heading>
-        <Button
-          aria-label={'update-dashboard'}
-          leftIcon={<SettingsIcon />}
-          variant='outline'
-          colorScheme='gray'
-          onClick={settingsOnOpen}
-        >
-          {t('dashboardSettings')}
-        </Button>
-      </Flex>
-      </>
+      <Box>
+        <Flex justify='space-between'>
+          <Heading>{dashboardId}</Heading>
+          <Button
+            aria-label={'update-dashboard'}
+            leftIcon={<SettingsIcon />}
+            variant='outline'
+            colorScheme='gray'
+            onClick={settingsOnOpen}
+          >
+            {t('dashboardSettings')}
+          </Button>
+        </Flex>
+        <Text fontSize='large'>{description}</Text>
+      </Box>
     );
   }
 

--- a/src/components/dashboard/dashboard.tsx
+++ b/src/components/dashboard/dashboard.tsx
@@ -132,6 +132,7 @@ function Dashboard() {
     <DashboardWrapper
       dashboardContents={renderDashboard()}
       dashboardId={dashboardId}
+      description={dashboard?.description}
     />
   )
 }

--- a/src/components/layout/breadcrumbs.tsx
+++ b/src/components/layout/breadcrumbs.tsx
@@ -1,19 +1,15 @@
 import React from 'react';
 import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, Text } from '@chakra-ui/react';
-import { useRouter } from 'next/router';
 import { selectDashboard, selectDashboardIdFromRoute } from 'ops-frontend/store/consoleSlice';
 import { useAppSelector } from 'ops-frontend/store/hooks';
 import { useTranslation } from 'react-i18next';
-import { dashboardQueryToDashboardRoute } from 'ops-frontend/utils/route';
 import { ChevronRightIcon } from '@chakra-ui/icons';
+import { useParams } from 'react-router-dom';
 
 export default function Breadcrumbs() {
-  const router = useRouter();
+  const { route = '' } = useParams();
 
-
-  const { dashboard: dashboardQuery } = router.query;
-  const dashboardRoute = dashboardQueryToDashboardRoute(dashboardQuery);
-  const dashboardId = useAppSelector(selectDashboardIdFromRoute(dashboardRoute));
+  const dashboardId = useAppSelector(selectDashboardIdFromRoute(route));
   const dashboard = useAppSelector(selectDashboard(dashboardId));
   const { t: cm } = useTranslation('common');
 
@@ -21,7 +17,7 @@ export default function Breadcrumbs() {
   function createBreadcrumbs() {
     const breadcrumbs = [];
 
-    breadcrumbs.push(createBreadcrumb(cm('dashboards'), '/', !dashboardRoute));
+    breadcrumbs.push(createBreadcrumb(cm('dashboards'), '/', !route));
 
     if (dashboard) {
       breadcrumbs.push(createBreadcrumb(dashboard.id, dashboard.route, true));

--- a/src/store/consoleSlice.ts
+++ b/src/store/consoleSlice.ts
@@ -189,7 +189,13 @@ export function selectDashboards(state: RootState): { [id: string]: Dashboard } 
 export function selectDashboardIdFromRoute(route: string) {
   return function (state: RootState): string {
     const { dashboards } = state.console;
-    const dashboardId = Object.keys(dashboards).find(dashboard => dashboards[dashboard].route === route);
+    const dashboardId = Object.keys(dashboards).find((id) => {
+      const r = dashboards[id].route;
+      const dashboardRoute = r.startsWith('/') ?
+        r.replace(/^(\/+)/, '') :
+        r;
+       return dashboardRoute === route;
+    });
     return dashboardId || '';
   }
 }


### PR DESCRIPTION
1. Adds description to dashboard page heading.
Addresses https://github.com/tinystacks/ops-frontend/issues/42
<img width="1507" alt="Screen Shot 2023-06-16 at 12 32 22 PM" src="https://github.com/tinystacks/ops-frontend/assets/13314870/f2d3bcac-b228-4c3a-8437-4c273b58aa41">

---

2. Adds spinner while dashboards are loading
Addresses https://github.com/tinystacks/ops-frontend/issues/32
<img width="1509" alt="Screen Shot 2023-06-16 at 12 58 54 PM" src="https://github.com/tinystacks/ops-frontend/assets/13314870/915cd4c2-cc70-4893-b237-47ef48c6571a">

---

3. Ignore preceding `/` characters when selection dashboard id from route.
Addresses https://github.com/tinystacks/ops-frontend/issues/39
<img width="1512" alt="Screen Shot 2023-06-16 at 1 24 20 PM" src="https://github.com/tinystacks/ops-frontend/assets/13314870/7dec63f1-f597-49f8-b36f-dcea8856a66c">
<img width="1509" alt="Screen Shot 2023-06-16 at 1 25 44 PM" src="https://github.com/tinystacks/ops-frontend/assets/13314870/4ea997a0-dd26-451b-860b-ba2353e4e919">
